### PR TITLE
Fix categories in RioV templates

### DIFF
--- a/lib/resources/templates/t1_axe_template
+++ b/lib/resources/templates/t1_axe_template
@@ -23,6 +23,6 @@
 
 {{Navbox The Mists of RioV}}
 
-[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Tools]]
+[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Felling]]
 
 <languages/>

--- a/lib/resources/templates/t1_hoe_template
+++ b/lib/resources/templates/t1_hoe_template
@@ -6,7 +6,7 @@
 |durability=#DURA
 }}
 
-'''#NAME Hoe''' is a tool added by [[The Mists of RioV 2]] mod, now [[The Mists of RioV]]. 
+'''#NAME Hoe''' is a tool added by [[The Mists of RioV 2]] mod, now [[The Mists of RioV]].
 
 ==Recipe==
 {{Cg/Crafting Table
@@ -20,6 +20,6 @@
 
 {{Navbox The Mists of RioV}}
 
-[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Tools]]
+[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Farming]]
 
 <languages/>

--- a/lib/resources/templates/t2_axe_template
+++ b/lib/resources/templates/t2_axe_template
@@ -20,6 +20,6 @@
 
 {{Navbox The Mists of RioV}}
 
-[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Mining]]
+[[Category:The Mists of RioV]][[Category:The Mists of RioV 2]][[Category:Felling]]
 
 <languages/>


### PR DESCRIPTION
As per [the category overhaul project](http://ftb.gamepedia.com/Feed_The_Beast_Wiki:Category_overhaul_project), you should not be putting things in Category:Tools aside from other categories, as it is a top-level category.

You were also putting axes in the mining category rather than felling.
